### PR TITLE
build: Addressed CVEs CVE-2020-25649 CVE-2020-17527

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-batch', version: versions.springBoot
 
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
-    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.2') {
+    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.0') {
         force = true
     }
     compile (group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.1') {
@@ -253,6 +253,18 @@ dependencies {
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
     compile group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
+    implementation('org.apache.tomcat.embed:tomcat-embed-core:9.0.40') {
+        because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
+                'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
+                'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
+                'it is possible that information could leak between requests'
+    }
+    implementation('org.apache.tomcat.embed:tomcat-embed-websocket:9.0.40') {
+        because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
+                'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
+                'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
+                'it is possible that information could leak between requests'
+    }
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,7 @@ dependencies {
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
     compile group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
+
     implementation('org.apache.tomcat.embed:tomcat-embed-core:9.0.40') {
         because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
                 'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-2107

### Change description ###

Fixed CVE-2020-17527 and CVE-2020-25649 by upgrading

tomcat-embed-core
tomcat-embed-websocket
jackson-databind

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
