### PR TITLE
RDCC-2837 changed all Compile and testCompile entries to implementation and testImplementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ idea {
 configurations {
     integrationTestCompile.extendsFrom testCompile
     integrationTestRuntime.extendsFrom testRuntime
-    functionalTestCompile.extendsFrom testCompile
+    functionalTestImplementation.extendsFrom testCompile
     functionalTestRuntime.extendsFrom testRuntime
 
 }
@@ -225,11 +225,15 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-batch', version: versions.springBoot
 
     implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
-    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson) {
-        force = true
+    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-databind') {
+        version {
+            strictly versions.jackson
+        }
     }
-    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson) {
-        force = true
+    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-core') {
+        version {
+            strictly versions.jackson
+        }
     }
     implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
     implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
@@ -316,19 +320,23 @@ dependencies {
     testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.15.1'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.2.8'
 
-    testImplementation(group: 'org.yaml', name: 'snakeyaml', version: '1.23') {
-        force = true
+    testImplementation(group: 'org.yaml', name: 'snakeyaml') {
+        version {
+            strictly '1.23'
+        }
     }
 
-    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.23') {
-        force = true
+    functionalTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
+        version {
+            strictly '1.23'
+        }
     }
 
-    functionalTestCompile sourceSets.main.runtimeClasspath
-    functionalTestCompile sourceSets.test.runtimeClasspath
+    functionalTestImplementation sourceSets.main.runtimeClasspath
+    functionalTestImplementation sourceSets.test.runtimeClasspath
 
-    smokeTestCompile sourceSets.main.runtimeClasspath
-    smokeTestCompile sourceSets.test.runtimeClasspath
+    smokeTestImplementation sourceSets.main.runtimeClasspath
+    smokeTestImplementation sourceSets.test.runtimeClasspath
 }
 
 dependencyCheck {
@@ -351,7 +359,7 @@ dependencyUpdates.resolutionStrategy = {
 gradle.startParameter.continueOnFailure = true
 
 bootJar {
-    archiveName = jarName
+    archiveFileName = jarName
     manifest {
         attributes('Implementation-Version': project.version.toString())
     }

--- a/build.gradle
+++ b/build.gradle
@@ -215,54 +215,54 @@ repositories {
 dependencies {
 
 
-    compile group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
+    implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: versions.springBoot
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: versions.springBoot
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-batch', version: versions.springBoot
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-batch', version: versions.springBoot
 
-    compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
-    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson) {
+    implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
+    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson) {
         force = true
     }
-    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson) {
+    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson) {
         force = true
     }
-    compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
-    compile group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
+    implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
+    implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
 
-    compile group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
-    compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
-    compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
-    compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
-    compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-    compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
 
     implementation 'com.github.hmcts:data-ingestion-lib:0.4.4.0'
     //Fix for CVE-2021-29425
     implementation 'commons-io:commons-io:2.8.0'
-    compile group: 'org.apache.camel', name: 'camel-bom', version: versions.camel, ext: 'pom'
-    compile group: 'org.apache.camel.springboot', name: 'camel-spring-boot-dependencies', version: versions.camel
+    implementation group: 'org.apache.camel', name: 'camel-bom', version: versions.camel, ext: 'pom'
+    implementation group: 'org.apache.camel.springboot', name: 'camel-spring-boot-dependencies', version: versions.camel
 
-    testCompile group: 'com.microsoft.azure', name: 'azure-storage-blob', version: '11.0.0'
+    testImplementation group: 'com.microsoft.azure', name: 'azure-storage-blob', version: '11.0.0'
 
-    compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
+    implementation group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
 
-    compile group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
 
-    compile group: 'org.apache.commons', name: 'commons-vfs2', version: '2.4.1'
-    compile group: 'com.jcraft', name: 'jsch', version: '0.1.55'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+    implementation group: 'org.apache.commons', name: 'commons-vfs2', version: '2.4.1'
+    implementation group: 'com.jcraft', name: 'jsch', version: '0.1.55'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
-    compile group: 'com.opencsv', name: 'opencsv', version: '3.7'
-    compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
+    implementation group: 'com.opencsv', name: 'opencsv', version: '3.7'
+    implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
-    compile group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
+    implementation group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
@@ -273,50 +273,50 @@ dependencies {
     smokeTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
-    testCompile("org.hamcrest:hamcrest-junit:2.0.0.0") {
+    testImplementation("org.hamcrest:hamcrest-junit:2.0.0.0") {
         exclude group: "org.hamcrest", module: "hamcrest-core"
         exclude group: "org.hamcrest", module: "hamcrest-library"
     }
 
-    testCompile (group: 'io.rest-assured', name: 'rest-assured', version: '4.1.2') {
+    testImplementation (group: 'io.rest-assured', name: 'rest-assured', version: '4.1.2') {
         exclude group: "com.sun.xml.bind", module: "jaxb-osgi"
     }
-    testCompile group: 'com.h2database', name: 'h2'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
-    testCompile group: 'org.mockito', name: 'mockito-inline', version: '3.1.0'
-    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.4'
+    testImplementation group: 'com.h2database', name: 'h2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.1.0'
+    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.4'
     testImplementation group: 'org.powermock', name: 'powermock-mockito-release-full', version: '1.5.4', ext: 'pom'
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
-    testCompile group: 'org.springframework.batch', name: 'spring-batch-test', version: '4.3.1'
+    testImplementation group: 'org.springframework.batch', name: 'spring-batch-test', version: '4.3.1'
 
-    testCompile 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
-    testCompile group: 'org.javatuples', name: 'javatuples', version: '1.2'
+    testImplementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
+    testImplementation group: 'org.javatuples', name: 'javatuples', version: '1.2'
 
-    testCompile(group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity) {
+    testImplementation(group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity) {
         exclude group: 'com.vladsch.flexmark', module: 'flexmark-all'
         exclude group: 'javax.websocket', module: 'javax.websocket-api'
     }
-    testCompile(group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity) {
+    testImplementation(group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity) {
         exclude group: 'com.vladsch.flexmark', module: 'flexmark-all'
         exclude group: 'javax.websocket', module: 'javax.websocket-api'
     }
-    testCompile(group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity) {
-        exclude group: 'com.vladsch.flexmark', module: 'flexmark-all'
-        exclude group: 'javax.websocket', module: 'javax.websocket-api'
-    }
-
-    testCompile(group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity) {
+    testImplementation(group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity) {
         exclude group: 'com.vladsch.flexmark', module: 'flexmark-all'
         exclude group: 'javax.websocket', module: 'javax.websocket-api'
     }
 
-    testCompile group: 'org.apache.camel', name: 'camel-test-spring-junit5', version: versions.camel
-    testCompile group: 'org.apache.camel', name: 'camel-test-junit5', version: versions.camel
-    testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.15.1'
-    testCompile group: 'org.postgresql', name: 'postgresql', version: '42.2.8'
+    testImplementation(group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity) {
+        exclude group: 'com.vladsch.flexmark', module: 'flexmark-all'
+        exclude group: 'javax.websocket', module: 'javax.websocket-api'
+    }
 
-    testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.23') {
+    testImplementation group: 'org.apache.camel', name: 'camel-test-spring-junit5', version: versions.camel
+    testImplementation group: 'org.apache.camel', name: 'camel-test-junit5', version: versions.camel
+    testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.15.1'
+    testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.2.8'
+
+    testImplementation(group: 'org.yaml', name: 'snakeyaml', version: '1.23') {
         force = true
     }
 


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RDCC-2837

Change description
changed all Compile and testCompile entries to implementation and testImplementation in the build.gradle file as the same are deprecated from gradle 7 onwards

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[ X] No