### PR TITLE
RDCC-4504 JRD LOAD -Nightly build failure -25/04/2022

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ dependencies {
     implementation group: 'io.projectreactor.netty', name: 'reactor-netty-core', version: '1.0.6'
     implementation group: 'io.projectreactor.netty', name: 'reactor-netty-http', version: '1.0.6'
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.4.14'
-    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.18'
+    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.19'
     implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
     
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDCC-4504

JIRA link (if applicable)

fix for cve 2022-22968

Change description

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[X] No