### PR TITLE
CVE fix: Bumped spring dependencies version to 5.3.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ def versions = [
         jackson            : '2.13.1',
         launchDarklySdk    : "5.8.1",
         camel              : '3.8.0',
-        log4j              : '2.17.1'
+        log4j              : '2.17.1',
+        springVersion      : '5.3.20'
 ]
 
 mainClassName = 'uk.gov.hmcts.reform.juddata.JudicialApplication'
@@ -242,17 +243,19 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: versions.springBoot
 
-    implementation group: 'org.springframework', name: 'spring-aop', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-aspects', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-context', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-context-support', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-expression', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-jcl', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-jdbc', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-orm', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-tx', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-web', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-webmvc', version: '5.3.18'
+    implementation group: 'org.springframework', name: 'spring-core', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-beans', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-aop', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-aspects', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-context', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-context-support', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-expression', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-jcl', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-orm', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-tx', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-web', version: versions.springVersion
+    implementation group: 'org.springframework', name: 'spring-webmvc', version: versions.springVersion
 
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-batch', version: versions.springBoot
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-freemarker', version: versions.springBoot
@@ -289,9 +292,6 @@ dependencies {
     implementation ('com.github.hmcts:data-ingestion-lib:0.5.1.4') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
     }
-
-    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.18'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
     //Fix for CVE-2021-29425
     implementation 'commons-io:commons-io:2.11.0'
     implementation group: 'org.apache.camel', name: 'camel-bom', version: versions.camel, ext: 'pom'
@@ -319,8 +319,6 @@ dependencies {
     implementation group: 'io.projectreactor.netty', name: 'reactor-netty-core', version: '1.0.6'
     implementation group: 'io.projectreactor.netty', name: 'reactor-netty-http', version: '1.0.6'
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.4.14'
-    implementation group: 'org.springframework', name: 'spring-core', version: '5.3.19'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '5.3.18'
     
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-4707


### Change description ###
Bumped spring dependencies version to 5.3.20


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
