### PR TITLE
RDCC-5534: Upgrading `launchdarkly-java-server-sdk` & `snakeyaml`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ def versions = [
         springHystrix      : '2.2.8.RELEASE',
         springfoxSwagger   : '2.9.2',
         jackson            : '2.13.1',
-        launchDarklySdk    : "5.8.1",
+        launchDarklySdk    : "5.10.2",
         camel              : '3.8.0',
         log4j              : '2.17.1',
         springVersion      : '5.3.20',
@@ -398,23 +398,7 @@ dependencies {
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
     testImplementation 'com.github.hmcts:fortify-client:1.2.0:all'
 
-    testImplementation(group: 'org.yaml', name: 'snakeyaml') {
-        version {
-            strictly '1.31'
-        }
-    }
-
-    functionalTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
-        version {
-            strictly '1.31'
-        }
-    }
-
-    integrationTestImplementation(group: 'org.yaml', name: 'snakeyaml') {
-        version {
-            strictly '1.31'
-        }
-    }
+	implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
 
     functionalTestImplementation sourceSets.main.runtimeClasspath
     functionalTestImplementation sourceSets.test.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,12 +20,4 @@
 <suppress until="2023-01-01">
     <cve>CVE-2022-31569</cve>
 </suppress>
-    <suppress>
-        <notes>Suppressed due to unavailability of updated version of launchdarkly-java-server-sdk</notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2022-25857</cve>
-        <cve>CVE-2022-38749</cve>
-        <cve>CVE-2022-38750</cve>
-        <cve>CVE-2022-38751</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5534

### Change description ###

Upgrading `launchdarkly-java-server-sdk` & `snakeyaml` to fix CVE-2022-38752

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
