### PR TITLE
RDCC-6073: Fix for `CVE-2022-41915`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -461,7 +461,7 @@ configurations.all {
     resolutionStrategy.eachDependency { details ->
         if (details.requested.group == 'io.netty'
                 && details.requested.name != 'netty-tcnative-boringssl-static' ) {
-            details.useVersion "4.1.77.Final"
+            details.useVersion "4.1.86.Final"
         }
 
         // Fix for CVE-2020-21913 & needs to be removed when camel-azure-starter is upgraded to latest version in data-ingestion-library


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6073

### Change description ###

Upgrading Netty version as a fix for `CVE-2022-41915`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
