### PR TITLE
RDCC-6609 - suppress CVE-2022-1471

### DIFF
--- a/charts/rd-judicial-data-load/Chart.yaml
+++ b/charts/rd-judicial-data-load/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Reference Data Team
 dependencies:
   - name: job
-    version: 0.7.10
+    version: 0.7.11
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 11.6.10

--- a/charts/rd-judicial-data-load/Chart.yaml
+++ b/charts/rd-judicial-data-load/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.1"
 description:  Data load from Judicial HR systems
 name: rd-judicial-data-load
 home: https://github.com/hmcts/rd-judicial-data-load
-version: 0.3.8
+version: 0.3.9
 
 maintainers:
   - name: Reference Data Team

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,4 +14,14 @@
     <suppress until="2024-01-01">
         <cve>CVE-2022-45046</cve>
     </suppress>
+
+
+    <suppress>
+        <notes><![CDATA[
+   file name: launchdarkly-java-server-sdk-5.10.7.jar (shaded: org.yaml:snakeyaml:1.32)
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2022-1471</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-6609


### Change description ###
Suppress CVE-2022-1471
Update job chart version to 0.7.11 since 0.7.10 is now deprecated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
