### PR TITLE
Fix CVE-2023-20860 - bump up spring framework to 5.3.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ def versions = [
         launchDarklySdk    : '5.10.7',
         camel              : '3.8.0',
         log4j              : '2.18.0',
-        springVersion      : '5.3.20',
+        springVersion      : '5.3.26',
         feign              : '3.8.0',
         logback            : '1.2.10',
         netty              : '1.1.2',


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSRD-159


### Change description ###
Moved to spring framework 5.3.26 to fix CVE-2023-20860


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
