### PR TITLE
DTSRD-1456

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -451,6 +451,29 @@ dependencyManagement {
         dependencySet(group: 'commons-fileupload', version: '1.5') {
             entry 'commons-fileupload'
         }
+
+        //        Resolves CVE-2023-4586
+        dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+            entry 'netty-buffer'
+            entry 'netty-codec'
+            entry 'netty-codec-dns'
+            entry 'netty-codec-http'
+            entry 'netty-codec-http2'
+            entry 'netty-codec-socks'
+            entry 'netty-common'
+            entry 'netty-handler'
+            entry 'netty-handler-proxy'
+            entry 'netty-resolver'
+            entry 'netty-resolver-dns'
+            entry 'netty-resolver-dns-classes-macos'
+            entry 'netty-resolver-dns-native-macos'
+            entry 'netty-transport'
+            entry 'netty-transport-classes-epoll'
+            entry 'netty-transport-classes-kqueue'
+            entry 'netty-transport-native-epoll'
+            entry 'netty-transport-native-kqueue'
+            entry 'netty-transport-native-unix-common'
+        }
     }
 }
 
@@ -489,11 +512,6 @@ applicationDefaultJvmArgs = ["-Dfile.encoding=UTF-8"]
 // Fix for CVE-2021-21295, CVE-2022-41881 & need to be removed with new Azure blob version
 configurations.all {
     resolutionStrategy.eachDependency { details ->
-        if (details.requested.group == 'io.netty'
-                && details.requested.name != 'netty-tcnative-boringssl-static') {
-            details.useVersion "4.1.94.Final"
-        }
-
         // Fix for CVE-2020-21913 & needs to be removed when camel-azure-starter is upgraded to latest version in data-ingestion-library
         if (details.requested.group == 'com.ibm.icu') {
             details.useVersion "66.1"

--- a/charts/rd-judicial-data-load/Chart.yaml
+++ b/charts/rd-judicial-data-load/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.1"
 description:  Data load from Judicial HR systems
 name: rd-judicial-data-load
 home: https://github.com/hmcts/rd-judicial-data-load
-version: 0.3.12
+version: 0.3.13
 
 maintainers:
   - name: Reference Data Team

--- a/charts/rd-judicial-data-load/Chart.yaml
+++ b/charts/rd-judicial-data-load/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
   - name: Reference Data Team
 dependencies:
   - name: job
-    version: 1.0.0
+    version: 1.1.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 11.6.10


### PR DESCRIPTION
- Updating netty versions to resolve CVE-2023-4586.
- Updating helm version; Version of job helm chart below 1.1.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-job/releases This configuration will stop working by 23/10/2023

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSRD-1456

### Change description ###

- Updating netty versions to resolve CVE-2023-4586.
- Updating helm version; Version of job helm chart below 1.1.0 is deprecated, please upgrade to latest release https://github.com/hmcts/chart-job/releases This configuration will stop working by 23/10/2023

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
